### PR TITLE
Don't reorder the drag and drop spot if an item is dragged outside of the list

### DIFF
--- a/lib/DraxList.js
+++ b/lib/DraxList.js
@@ -31,7 +31,7 @@ const defaultStyles = react_native_1.StyleSheet.create({
     draggingStyle: { opacity: 0 },
     dragReleasedStyle: { opacity: 0.5 },
 });
-exports.DraxList = ({ data, style, itemStyles, renderItemContent, renderItemHoverContent, onItemReorder, id: idProp, reorderable: reorderableProp, onDragPositionChanged, onDragStart, onDragEnd, ...props }) => {
+exports.DraxList = ({ data, style, wrapperStyles, itemStyles, renderItemContent, renderItemHoverContent, onItemReorder, id: idProp, reorderable: reorderableProp, onDragPositionChanged, onDragStart, onDragEnd, ...props }) => {
     // Copy the value of the horizontal property for internal use.
     const { horizontal = false } = props;
     // Get the item count for internal use.
@@ -64,8 +64,8 @@ exports.DraxList = ({ data, style, itemStyles, renderItemContent, renderItemHove
     const shiftsRef = react_1.useRef([]);
     // Maintain cache of reordered list indexes until data updates.
     const [originalIndexes, setOriginalIndexes] = react_1.useState([]);
-    // Maintain the index the item is currently dragged to
-    const draggedToIndex = react_1.useRef(undefined);
+    // Maintain the toPayload the item is currently dragged to
+    const curToPayload = react_1.useRef(undefined);
     // Adjust measurements and shift value arrays as item count changes.
     react_1.useEffect(() => {
         const itemMeasurements = itemMeasurementsRef.current;
@@ -233,6 +233,7 @@ exports.DraxList = ({ data, style, itemStyles, renderItemContent, renderItemHove
     // Reset all shift values.
     const resetShifts = react_1.useCallback(() => {
         shiftsRef.current.forEach((shift) => {
+            shift.targetValue = 0;
             shift.animatedValue.setValue(0);
         });
     }, []);
@@ -320,9 +321,7 @@ exports.DraxList = ({ data, style, itemStyles, renderItemContent, renderItemHove
             const fromPayload = dragged && (dragged.parentId === id)
                 ? dragged.payload
                 : undefined;
-            const toPayload = (fromPayload !== undefined && receiver && receiver.parentId === id)
-                ? receiver.payload
-                : undefined;
+            const toPayload = curToPayload.current || ((fromPayload !== undefined && receiver && receiver.parentId === id) ? receiver.payload : undefined);
             if (fromPayload !== undefined) {
                 // If dragged item was ours, reset shifts.
                 resetShifts();
@@ -359,21 +358,23 @@ exports.DraxList = ({ data, style, itemStyles, renderItemContent, renderItemHove
         onItemReorder,
     ]);
     // Monitor drags to react with item shifts and auto-scrolling.
-    const onMonitorDragOver = react_1.useCallback(({ dragged, receiver, monitorOffsetRatio }) => {
+    const onMonitorDragOver = react_1.useCallback(({ dragged, receiver, monitorOffsetRatio, dragAbsolutePosition }) => {
+        // Only update things if we are dragging within the list itself, otherwise leave things alone
+        const dragIsWithinList = contentSizeRef.current && dragAbsolutePosition.y < contentSizeRef.current.y && dragAbsolutePosition.y > 0 && dragAbsolutePosition.x < contentSizeRef.current.x && dragAbsolutePosition.x > 0;
         // First, check if we need to shift items.
-        if (reorderable && dragged.parentId === id) {
+        if (reorderable && dragged.parentId === id && dragIsWithinList) {
             // One of our list items is being dragged.
             const fromPayload = dragged.payload;
             // Find its current index in the list for the purpose of shifting.
             const toPayload = receiver?.parentId === id
                 ? receiver.payload
                 : fromPayload;
-            if (draggedToIndex.current !== undefined
-                && toPayload.index !== draggedToIndex.current
+            if (curToPayload.current !== undefined
+                && toPayload.index !== curToPayload.current.index
                 && onDragPositionChanged) {
                 onDragPositionChanged(toPayload.index);
             }
-            draggedToIndex.current = toPayload.index;
+            curToPayload.current = toPayload;
             updateShifts(fromPayload, toPayload);
         }
         // Next, see if we need to auto-scroll.
@@ -410,7 +411,7 @@ exports.DraxList = ({ data, style, itemStyles, renderItemContent, renderItemHove
     const onMonitorDragEnd = react_1.useCallback(({ dragged, receiver }) => handleInternalDragEnd(dragged, receiver), [handleInternalDragEnd]);
     // Monitor drag drops to stop scrolling, update shifts, and possibly reorder.
     const onMonitorDragDrop = react_1.useCallback(({ dragged, receiver }) => handleInternalDragEnd(dragged, receiver), [handleInternalDragEnd]);
-    return id ? (react_1.default.createElement(DraxView_1.DraxView, { id: id, style: style, scrollPositionRef: scrollPositionRef, onMeasure: onMeasureContainer, onMonitorDragOver: onMonitorDragOver, onMonitorDragExit: onMonitorDragExit, onMonitorDragEnd: onMonitorDragEnd, onMonitorDragDrop: onMonitorDragDrop },
+    return id ? (react_1.default.createElement(DraxView_1.DraxView, { id: id, style: wrapperStyles, scrollPositionRef: scrollPositionRef, onMeasure: onMeasureContainer, onMonitorDragOver: onMonitorDragOver, onMonitorDragExit: onMonitorDragExit, onMonitorDragEnd: onMonitorDragEnd, onMonitorDragDrop: onMonitorDragDrop },
         react_1.default.createElement(DraxSubprovider_1.DraxSubprovider, { parent: { id, nodeHandleRef } },
-            react_1.default.createElement(react_native_1.FlatList, Object.assign({}, props, { ref: setFlatListRefs, renderItem: renderItem, onScroll: onScroll, onContentSizeChange: onContentSizeChange, data: reorderedData }))))) : null;
+            react_1.default.createElement(react_native_1.FlatList, Object.assign({}, props, { style: style, ref: setFlatListRefs, renderItem: renderItem, onScroll: onScroll, onContentSizeChange: onContentSizeChange, data: reorderedData }))))) : null;
 };


### PR DESCRIPTION
This was causing the dragged item to snap back to it's initial spot in the list when it should most likely stay where it last was.
